### PR TITLE
Switch logger to come from the user

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # Version history
 
+## v0.5.0 (2021-05-06)
+
+- Allow custom loggers to be injected. Stop relying on std.
+
 ## v0.4.1 (2021-04-13)
 
 - Bump std to 0.93.0.

--- a/README.md
+++ b/README.md
@@ -131,6 +131,24 @@ client.unique("users.unique", user.id);
   Tags are key-value pairs that are appended to each metric. Values need to be
   strings. If a value is the empty string, that tag will be skipped.
 
+- `logger`: (Logger?) (Default: no logging)
+
+  This library will not log anything by default. However, if you'd get a little
+  more feedback about how the StatsD connection is going, you can get that by
+  providing a logger object here. The typescript types of this parameter is
+  pretty general, but should be compatible with most versions of the std
+  library's logger:
+
+  ```ts
+  import * as log from "https://deno.land/std@0.95.0/log/mod.ts";
+
+  await log.setup({ ... })
+
+  const c = new StatsDClient({
+    logger: log.getLogger("statsd"),
+  });
+  ```
+
 ## Client Methods
 
 - `count(key: string, num, opts?: MetricOpts)`
@@ -346,27 +364,3 @@ Some params can be overridden for each metric with the MetricOpts object.
 - `sampleRate` - To use a custom sampleRate for this metric.
 - `tags` - To add some extra tags to this metric. (They are merged with the
   global tags)
-
-### Logging
-
-This library uses the std library's logger for its own internal logging. If
-those logs would be useful for debugging, then the `statsd` logger can be
-configured like so:
-
-```ts
-import * as log from "https://deno.land/std@0.92.0/log/mod.ts";
-
-await log.setup({
-  handlers: {
-    console: new log.handlers.ConsoleHandler("DEBUG"),
-  },
-  loggers: {
-    statsd: {
-      level: "INFO",
-      handlers: ["console"],
-    },
-  },
-});
-```
-
-Be sure to do this BEFORE initializing the `StatsDClient`.

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export * as log from "https://deno.land/std@0.95.0/log/mod.ts";
+// None yet.

--- a/mod.ts
+++ b/mod.ts
@@ -9,5 +9,6 @@ export type { MetricOpts } from "./src/types/MetricOpts.ts";
 export type { EventOpts } from "./src/types/EventOpts.ts";
 export type { ServiceCheckOpts } from "./src/types/ServiceCheckOpts.ts";
 export type { Tags } from "./src/types/Tags.ts";
+export type { Logger } from "./src/types/Logger.ts";
 
 export { StatsDClient } from "./src/StatsDClient.ts";

--- a/smokeTests/highFrequency.ts
+++ b/smokeTests/highFrequency.ts
@@ -1,5 +1,5 @@
 import { StatsDClient } from "../mod.ts";
-import { log } from "../deps.ts";
+import { log } from "../testDeps.ts";
 
 /*
  * Envirnoment: StatsD server, running in docker.
@@ -26,6 +26,7 @@ const c = new StatsDClient({
     proto: "logger",
   },
   dialect: "datadog",
+  logger: log.getLogger("statsd"),
 });
 
 main();

--- a/smokeTests/longPauses.ts
+++ b/smokeTests/longPauses.ts
@@ -1,5 +1,5 @@
 import { StatsDClient } from "../mod.ts";
-import { log } from "../deps.ts";
+import { log } from "../testDeps.ts";
 
 /*
  * Envirnoment: StatsD server, running in docker.

--- a/smokeTests/steadyStream.ts
+++ b/smokeTests/steadyStream.ts
@@ -1,5 +1,5 @@
 import { StatsDClient } from "../mod.ts";
-import { log } from "../deps.ts";
+import { log } from "../testDeps.ts";
 
 /*
  * Envirnoment: StatsD server, running in docker.
@@ -26,6 +26,7 @@ const c = new StatsDClient({
     proto: "udp",
   },
   dialect: "datadog",
+  logger: log.getLogger("statsd"),
 });
 
 setInterval(sendOne, 1000);

--- a/src/network/LoggerClient.ts
+++ b/src/network/LoggerClient.ts
@@ -1,5 +1,5 @@
 import { Client } from "../types/Client.ts";
-import { log } from "../../deps.ts";
+import { Logger } from "../types/Logger.ts";
 
 /**
  * Client that only delivers packets to the log.
@@ -9,9 +9,10 @@ import { log } from "../../deps.ts";
 export class LoggerClient implements Client {
   #isClosed = false;
 
-  #logger = log.getLogger("statsd");
+  #logger: Logger;
 
-  constructor() {
+  constructor({ logger }: { logger: Logger }) {
+    this.#logger = logger;
   }
 
   queueData(data: string) {

--- a/src/network/SocketClient.ts
+++ b/src/network/SocketClient.ts
@@ -1,8 +1,8 @@
 import { Client } from "../types/Client.ts";
 import { StatsDError } from "../StatsDError.ts";
 import { exponentialBackoff } from "../utils/exponentialBackoff.ts";
-import { log } from "../../deps.ts";
 import { describeAddr } from "../utils/describeAddr.ts";
+import { Logger } from "../types/Logger.ts";
 
 const encoder: TextEncoder = new TextEncoder();
 
@@ -12,6 +12,7 @@ type TCPOpts = {
   port: number;
   maxQueue: number;
   maxDelay: number;
+  logger: Logger;
 };
 
 type UnixOpts = {
@@ -19,6 +20,7 @@ type UnixOpts = {
   path: string;
   maxQueue: number;
   maxDelay: number;
+  logger: Logger;
 };
 
 /**
@@ -39,12 +41,13 @@ export class SocketClient implements Client {
   #queue: string[] = [];
   #flushPromise: Promise<void> | null = null;
 
-  #logger = log.getLogger("statsd");
+  #logger: Logger;
 
   // Simple constructor:
   constructor(opts: TCPOpts | UnixOpts) {
     this.#maxQueue = opts.maxQueue;
     this.#maxDelay = opts.maxDelay;
+    this.#logger = opts.logger;
     switch (opts.mode) {
       case "tcp":
         this.#opts = {

--- a/src/network/UDPClient.ts
+++ b/src/network/UDPClient.ts
@@ -39,7 +39,7 @@ export class UDPClient implements Client {
       hostname: host,
       port: port,
     };
-    this.#conn = _connectUDP(this.#addr);
+    this.#conn = _connectUDP();
     this.#logger = logger;
     this.#logger.info(
       `StatsD.UDP: Connected via ${describeAddr(this.#conn.addr)}`,
@@ -125,7 +125,7 @@ export class UDPClient implements Client {
   }
 }
 
-function _connectUDP(addr: Deno.NetAddr): Deno.DatagramConn {
+function _connectUDP(): Deno.DatagramConn {
   if (!Deno.listenDatagram) {
     throw new StatsDError(
       "Cannot connect to UDP. Try enabling unstable APIs with '--unstable'",

--- a/src/network/UDPClient.ts
+++ b/src/network/UDPClient.ts
@@ -1,6 +1,6 @@
 import { Client } from "../types/Client.ts";
 import { StatsDError } from "../StatsDError.ts";
-import { log } from "../../deps.ts";
+import { Logger } from "../types/Logger.ts";
 import { describeAddr } from "../utils/describeAddr.ts";
 
 const encoder: TextEncoder = new TextEncoder();
@@ -10,6 +10,7 @@ type ConstructorOpts = {
   port: number;
   mtu: number;
   maxDelay: number;
+  logger: Logger;
 };
 
 /**
@@ -29,16 +30,17 @@ export class UDPClient implements Client {
   #buffer: Uint8Array;
   #idx = 0;
 
-  #logger = log.getLogger("statsd");
+  #logger: Logger;
 
   // Simple constructor:
-  constructor({ host, port, mtu, maxDelay }: ConstructorOpts) {
+  constructor({ host, port, mtu, maxDelay, logger }: ConstructorOpts) {
     this.#addr = {
       transport: "udp",
       hostname: host,
       port: port,
     };
     this.#conn = _connectUDP(this.#addr);
+    this.#logger = logger;
     this.#logger.info(
       `StatsD.UDP: Connected via ${describeAddr(this.#conn.addr)}`,
     );
@@ -101,10 +103,10 @@ export class UDPClient implements Client {
   private async _write(data: Uint8Array): Promise<void> {
     const num = await this.#conn.send(data, this.#addr);
 
-    this.#logger.debug(() =>
+    this.#logger.debug(
       `StatsD.UDP: Sending ${data.byteLength}-byte packet to ${
         describeAddr(this.#addr)
-      }`
+      }`,
     );
 
     if (num < 0) {

--- a/src/types/LibConfig.ts
+++ b/src/types/LibConfig.ts
@@ -1,4 +1,5 @@
 import { Tags } from "./Tags.ts";
+import { Logger } from "./Logger.ts";
 
 export interface LibConfig {
   /**
@@ -60,6 +61,23 @@ export interface LibConfig {
    * @default {}
    */
   globalTags?: Tags;
+
+  /**
+   * This library will not log anything by default. However, if you'd get a little more feedback about how the StatsD
+   * connection is going, you can get that by providing a logger object here. The type of this parameter is pretty
+   * vague, but should be compatible with most versions of the std library's logger:
+   * 
+   * @example
+   *   import * as log from "https://deno.land/std@0.95.0/log/mod.ts";
+   *
+   *   await log.setup({ ... })
+   *
+   *   const c = new StatsDClient({
+   *     ...
+   *     logger: log.getLogger("statsd"),
+   *   });
+   */
+  logger?: Logger;
 }
 
 /**

--- a/src/types/Logger.ts
+++ b/src/types/Logger.ts
@@ -1,0 +1,10 @@
+/**
+ * Logger defines a logging type that can be injected into the library to enable logging. The API defined is a subset of
+ * the std logger's API, and should be compatible with it.
+ */
+export type Logger = {
+  debug: (msg: string) => unknown;
+  info: (msg: string) => unknown;
+  warning: (msg: string) => unknown;
+  error: (msg: string) => unknown;
+};

--- a/testDeps.ts
+++ b/testDeps.ts
@@ -1,3 +1,4 @@
 export * as asserts from "https://deno.land/std@0.92.0/testing/asserts.ts";
 export { BufReader } from "https://deno.land/std@0.92.0/io/mod.ts";
 export { join as joinPath } from "https://deno.land/std/path/mod.ts";
+export * as log from "https://deno.land/std@0.95.0/log/mod.ts";


### PR DESCRIPTION
Directly accessing the std logger and expecting the user to configure it is really janky API, since it depends on std versions lining up exactly, which won't always happen. Instead, this PR defines a subset of the std logger API, and switches the library to depend on that. This lets us have our fancy logger, but gives the user full control over it.

Maybe deno will get built-in dependency injection at some point, or a better pattern will emerge. But this is good enough for now. 