### PR TITLE
Tweak CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,15 @@ os:
   # Note: osx seems to exhibit some of the strange lockups that I saw in github's actions.
   # Namely, that UDP packets fail to send, causing test timeouts. Research more later.
 dist: xenial
+
+# Deno not officially supported, so fall back on a generic image, and install ourselves:
+language: minimal
 before_install:
   - pwd
   - ./.ci/deno_install.sh
   - export DENO_INSTALL="$HOME/.deno"
   - export PATH="$DENO_INSTALL/bin:$PATH"
+
+# Test script is easy:
 script: 
   - deno test -A --unstable

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
-language: default
 os:
-  - ubuntu
+  - linux
   # - osx
   # Note: osx seems to exhibit some of the strange lockups that I saw in github's actions.
   # Namely, that UDP packets fail to send, causing test timeouts. Research more later.
+dist: xenial
 before_install:
   - pwd
-  - curl -fsSL https://deno.land/x/install/install.sh | sh
+  - ./.ci/deno_install.sh
   - export DENO_INSTALL="$HOME/.deno"
   - export PATH="$DENO_INSTALL/bin:$PATH"
 script: 


### PR DESCRIPTION
- Drop default language, since it was complaining about it.
- Specify os correctly. Linux + a specific dist.
- Install deno using cached script instead of `curl | sh`