### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ os:
   # - osx
   # Note: osx seems to exhibit some of the strange lockups that I saw in github's actions.
   # Namely, that UDP packets fail to send, causing test timeouts. Research more later.
-dist: xenial
+dist: bionic
 
 # Deno not officially supported, so fall back on a generic image, and install ourselves:
 language: minimal


### PR DESCRIPTION
Seems that deno accidentally broke support on older linux distros, since a dependency of a dependency used a method only available in newer versions of glibc. (See: denoland/deno#13516)

This PR bumps the CI distro to be "bionic beaver" to side-step that issue, and get the build healthy again.